### PR TITLE
fix bug in CPR comparative assessment

### DIFF
--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -1465,7 +1465,8 @@ export const getReferenceScores = createSelector(
         // 2. get reference countries if scores present
         if (hasCountryDimScore) {
           // these are the countries that we are comparing our country to
-          // if country high income country then compare with all other HI
+          // if country high income AND OECD country then
+          //   compare it with all other HI AND OECD countries
           // if not, compare with region/subregion
           let referenceCountries;
           if (isCountryHighIncome(country) && isCountryOECD(country)) {

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -1470,7 +1470,7 @@ export const getReferenceScores = createSelector(
           let referenceCountries;
           if (isCountryHighIncome(country) && isCountryOECD(country)) {
             referenceCountries = countries.filter(
-              c => isCountryHighIncome(c) && isCountryOECD(country),
+              c => isCountryHighIncome(c) && isCountryOECD(c),
             );
           } else if (
             SUBREGIONS_FOR_COMPARISON_CPR.indexOf(country.subregion_code) > -1


### PR DESCRIPTION
 filtering of reference countries should of course use the reference country (`c`) not the country itself (`country`)

see also #141 for previous discussions
https://github.com/HumanRightsMeasurementInitiative/hrmi-dataportal/issues/141